### PR TITLE
add better error messages

### DIFF
--- a/loco-graphics-helper/rct_graphics_helper_panel.py
+++ b/loco-graphics-helper/rct_graphics_helper_panel.py
@@ -229,7 +229,10 @@ class GraphicsHelperPanel(bpy.types.Panel):
 
         components = get_car_components(cars)
         if len(components) == 0:
-            return   
+            col = layout.column()
+            col.label(text="No cars detected.")
+            col.label(text="Ensure at least one BODY is parented to a CAR")
+            return
         row = layout.row()
         row.label("Car(s) details:")
 
@@ -250,7 +253,7 @@ class GraphicsHelperPanel(bpy.types.Panel):
             back_name = '' if back is None else back.name
             mid_point_x = component.get_preferred_body_midpoint()
             if not math.isclose(body.matrix_world.translation[0], mid_point_x, rel_tol=1e-4):
-                warning = "BODY LOCATION IS NOT AT PREFERRED MID X POINT! {}".format(mid_point_x)
+                warning = "BODY LOCATION IS NOT AT PREFERRED MID X POINT! {}".format(round(mid_point_x,1))
 
             if not front is None:
                 front_position = component.get_bogie_position(SubComponent.FRONT)

--- a/loco-graphics-helper/vehicle.py
+++ b/loco-graphics-helper/vehicle.py
@@ -168,7 +168,7 @@ def get_car_components(cars) -> List[VehicleComponent]:
         component_animations = [x for x in car.children if x.loco_graphics_helper_object_properties.object_type == 'ANIMATION']
 
         if len(component_bodies) != 1:
-            print("Malformed car {}".format(car.name))
+            print("Car {} requires at least one child BODY".format(car.name))
             continue
 
         if len(component_bogies) != 2:


### PR DESCRIPTION
Some light UI improvements while I can't build the game.

This now tells you what to do
![image](https://github.com/user-attachments/assets/f4df65d2-02b8-42ca-a1ba-b6f19ce7eedf)

This is now readable. In my opinion it should not complain if it's up to 0.5 pixels off, but that can be discussed for a separate PR.
![image](https://github.com/user-attachments/assets/4fbbba78-e0c4-425e-9926-4bcd2f431d62)

Console error message is clarified
![image](https://github.com/user-attachments/assets/9106334e-2f33-4155-b774-b8691f2e2fd9)
